### PR TITLE
Make bot compile and add dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+target
+config_example.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,6 @@ FROM debian:buster-slim
 COPY --from=builder /usr/local/cargo/bin/auto-invite-matrix-bot /usr/local/bin/auto-invite-matrix-bot
 RUN apt-get update && apt-get install -y libssl1.1 ca-certificates && rm -rf /var/lib/apt/lists/*
 
+WORKDIR /
+
 CMD ["auto-invite-matrix-bot"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ RUN cargo install --path .
 
 FROM debian:buster-slim
 COPY --from=builder /usr/local/cargo/bin/auto-invite-matrix-bot /usr/local/bin/auto-invite-matrix-bot
-RUN apt-get update && apt-get install -y libssl1.1 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libssl1.1 ca-certificates && rm -rf /var/lib/apt/lists/*
 
 CMD ["auto-invite-matrix-bot"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,6 @@ RUN cargo install --path .
 
 FROM debian:buster-slim
 COPY --from=builder /usr/local/cargo/bin/auto-invite-matrix-bot /usr/local/bin/auto-invite-matrix-bot
+RUN apt-get update && apt-get install -y libssl1.1 && rm -rf /var/lib/apt/lists/*
 
-CMD ["auto-invite-matrix-bot", "--config /data/config.yaml"]
+CMD ["auto-invite-matrix-bot"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM rust as builder
+
+WORKDIR /opt/auto-invite-matrix-bot
+COPY . .
+RUN cargo install --path .
+
+FROM debian:buster-slim
+COPY --from=builder /usr/local/cargo/bin/auto-invite-matrix-bot /usr/local/bin/auto-invite-matrix-bot
+
+CMD ["auto-invite-matrix-bot", "--config /data/config.yaml"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -438,10 +438,10 @@ async fn do_stuff(config: &Config, server: &Homeserver) -> Result<(), failure::E
 #[derive(Clap)]
 #[clap(version = "0.1.0", author = "MTRNord")]
 struct Opts {
-    #[clap(short = "c", long = "config", default_value = "config.yaml")]
+    #[clap(short = 'c', long = "config", default_value = "config.yaml")]
     config: String,
     /// A level of verbosity, and can be used multiple times
-    #[clap(short = "v", long = "verbose", parse(from_occurrences))]
+    #[clap(short = 'v', long = "verbose", parse(from_occurrences))]
     verbose: i32,
 }
 


### PR DESCRIPTION
In order to use the bot I needed it to be packaged in a docker container, so I created a dockerfile. I've also fixed it not compiling, presumably due to some tiny silly library update. If you don't want the Dockerfile in this repo that's fine. I'll happily open a PR just with the compile fix.

I think the usage example is also no longer accurate, I needed to do `auto-invite-matrix-bot --config=/path/to/config.yml`.